### PR TITLE
Making changes for dropwizard 9

### DIFF
--- a/dropwizard/pom.xml
+++ b/dropwizard/pom.xml
@@ -16,7 +16,7 @@
     <description>Helpers for making it easier to use Curator in a Dropwizard application.</description>
 
     <properties>
-        <dropwizard.version>[0.7.1,0.8.0]</dropwizard.version>
+        <dropwizard.version>[0.7.1,0.9.0]</dropwizard.version>
     </properties>
 
     <dependencies>

--- a/dropwizard/src/main/java/com/bazaarvoice/curator/dropwizard/ZooKeeperConfiguration.java
+++ b/dropwizard/src/main/java/com/bazaarvoice/curator/dropwizard/ZooKeeperConfiguration.java
@@ -14,6 +14,7 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 
 import javax.validation.constraints.NotNull;
 import java.util.concurrent.ThreadFactory;
@@ -25,6 +26,7 @@ public class ZooKeeperConfiguration {
 
     @NotNull
     @JsonProperty("connectString")
+    @UnwrapValidatedValue(false)
     private Optional<String> _connectString = Optional.absent();
 
     @JsonProperty("namespace")


### PR DESCRIPTION
I have no idea if this is sufficient, but we're attempting to use the dropwizard curator extension with Dropwizard 9 and this was one necessary change. Without it we got the following stacktrace:
```
Exception in thread "main" javax.validation.UnexpectedTypeException: HV000186: The constraint of type 'javax.validation.constraints.NotNull' defined on 'emodb.zookeeperConfiguration._connectString' has multiple matching constraint validators which is due to an additional value handler of type 'io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper'. It is unclear which value needs validating. Clarify configuration via @UnwrapValidatedValue.
	at org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree.getConstraintValidatorInstanceForAutomaticUnwrapping(ConstraintTree.java:266)
	at org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree.getInitializedConstraintValidator(ConstraintTree.java:163)
	at org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree.validateConstraints(ConstraintTree.java:116)
	at org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree.validateConstraints(ConstraintTree.java:87)
	at org.hibernate.validator.internal.metadata.core.MetaConstraint.validateConstraint(MetaConstraint.java:73)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateMetaConstraint(ValidatorImpl.java:592)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateConstraint(ValidatorImpl.java:555)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateConstraintsForDefaultGroup(ValidatorImpl.java:490)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateConstraintsForCurrentGroup(ValidatorImpl.java:454)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateInContext(ValidatorImpl.java:406)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateCascadedConstraint(ValidatorImpl.java:770)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateCascadedConstraints(ValidatorImpl.java:656)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateInContext(ValidatorImpl.java:415)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateCascadedConstraint(ValidatorImpl.java:770)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateCascadedConstraints(ValidatorImpl.java:656)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validateInContext(ValidatorImpl.java:415)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validate(ValidatorImpl.java:204)
```