### PR TITLE
Update dependencies.

### DIFF
--- a/core/src/test/java/com/bazaarvoice/curator/ResolvingEnsembleProviderTest.java
+++ b/core/src/test/java/com/bazaarvoice/curator/ResolvingEnsembleProviderTest.java
@@ -13,7 +13,8 @@ import static org.mockito.Mockito.when;
 
 public class ResolvingEnsembleProviderTest {
 
-    private final ResolvingEnsembleProvider.Resolver _resolver = mock(ResolvingEnsembleProvider.Resolver.class);
+    private final ResolvingEnsembleProvider.ResolvingEnsembleProviderDelegate.Resolver _resolver =
+            mock(ResolvingEnsembleProvider.ResolvingEnsembleProviderDelegate.Resolver.class);
 
     @Test
     public void testNameResolves() throws Exception {
@@ -97,7 +98,9 @@ public class ResolvingEnsembleProviderTest {
     }
 
     private ResolvingEnsembleProvider newProvider(String connectString) {
-        return new ResolvingEnsembleProvider(connectString, _resolver);
+        return new ResolvingEnsembleProvider(new ResolvingEnsembleProvider.ResolvingEnsembleProviderDelegate(
+                connectString, _resolver
+        ));
     }
 
     private ResolverOngoingStubbing whenQueried(String domain) throws Exception {

--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -6,14 +6,8 @@
 >
     <suppress>
         <notes><![CDATA[
-   file name: jackson-datatype-jdk7-2.6.7.jar
-   ]]></notes>
-        <cve>CVE-2016-7051</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: jackson-datatype-jdk7-2.6.7.jar
-   ]]></notes>
-        <cve>CVE-2016-3720</cve>
+    file name: curator-framework-2.12.0.jar
+    ]]></notes>
+        <cve>CVE-2016-5017</cve>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.minimum.version>1.7</java.minimum.version>
-        <curator.version>2.12.0</curator.version>
+        <curator.version>4.0.1</curator.version>
         <guava.version>20.0</guava.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <zookeeper.version>3.4.11</zookeeper.version>
+        <zookeeper.version>3.4.13</zookeeper.version>
         <logback.version>1.2.3</logback.version>
-        <jackson.version>2.9.4</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
+        <jetty.version>9.4.12.v20180830</jetty.version>
     </properties>
 
     <build>
@@ -44,7 +45,7 @@
                 <!-- Make sure we always turn all warnings on during compilation. -->
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <source>1.7</source>
                         <target>1.7</target>
@@ -56,7 +57,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>1.3.1</version>
+                    <version>3.3.1</version>
                     <executions>
                         <execution>
                             <goals>
@@ -75,7 +76,7 @@
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.2</version>
+                    <version>1.6.8</version>
                     <extensions>true</extensions>
                     <configuration>
                         <serverId>sonatype-nexus-staging</serverId>
@@ -86,6 +87,25 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <requireUpperBoundDeps/>
+                                <dependencyConvergence/>
+                            </rules>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
@@ -123,6 +143,12 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -158,6 +184,48 @@
             </dependency>
 
             <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlets</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-continuation</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
@@ -167,7 +235,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.9.5</version>
+                <version>2.21.0</version>
                 <scope>test</scope>
             </dependency>
 
@@ -176,6 +244,7 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,10 +21,11 @@
             <artifactId>curator-framework</artifactId>
         </dependency>
 
+        <!-- curator-test >= 3 is incompatible with ZooKeeper < 3.5 -->
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>${curator.version}</version>
+            <version>2.12.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Make ResolvingEnsembleProvider effectively a no-op on ZooKeeper versions
that make it unnecessary.