### PR TITLE
Update dependencies with CVEs

### DIFF
--- a/dropwizard/pom.xml
+++ b/dropwizard/pom.xml
@@ -16,7 +16,7 @@
     <description>Helpers for making it easier to use Curator in a Dropwizard application.</description>
 
     <properties>
-        <dropwizard.version>1.3.7</dropwizard.version>
+        <dropwizard.version>1.3.12</dropwizard.version>
     </properties>
 
     <dependencies>

--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression"
-        xsi:schemaLocation="https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression suppression.xsd"
->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
     <suppress>
         <notes><![CDATA[
     file name: slf4j-api-1.7.25.jar
     ]]></notes>
         <cve>CVE-2018-8088</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: jetty-xml-9.4.12.v20180830.jar
+    ]]></notes>
+        <cve>CVE-2019-10241</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: guava-20.0.jar
+    ]]></notes>
+        <cve>CVE-2018-10237</cve>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <curator.version>4.0.1</curator.version>
         <guava.version>20.0</guava.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <zookeeper.version>3.4.13</zookeeper.version>
+        <zookeeper.version>3.4.14</zookeeper.version>
         <logback.version>1.2.3</logback.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <dependency.check.skip>false</dependency.check.skip>
     </properties>
@@ -58,7 +58,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>3.3.4</version>
+                    <version>5.0.0</version>
                     <executions>
                         <execution>
                             <goals>
@@ -67,9 +67,7 @@
                             <configuration>
                                 <skip>${dependency.check.skip}</skip>
                                 <failBuildOnCVSS>6</failBuildOnCVSS>
-                                <suppressionFile>
-                                    ${session.executionRootDirectory}/owasp-suppression.xml
-                                </suppressionFile>
+                                <suppressionFile>${session.executionRootDirectory}/owasp-suppression.xml</suppressionFile>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
Updated zookeeper, jackson, and dropwizard dependencies to address open CVEs. Added guava to suppression file since there is no current plan to upgrade guava version. Added jetty to suppression since there is no version of dropwizard with a newer version of jetty.