### PR TITLE
Revert Update to Zookeeper 3.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <curator.version>4.0.1</curator.version>
         <guava.version>28.0-jre</guava.version>
         <slf4j.version>1.7.26</slf4j.version>
-        <zookeeper.version>3.5.5</zookeeper.version>
+        <zookeeper.version>3.4.14</zookeeper.version>
         <logback.version>1.2.3</logback.version>
         <jackson.version>2.9.9</jackson.version>
         <jetty.version>9.4.19.v20190610</jetty.version>


### PR DESCRIPTION
We're seeing issues with Zookeeper 3.5.5 causing test failures here. In an effort to get other features and updates released, we'll revert that commit for now, do the release, and then address those failures in a new PR.